### PR TITLE
[FEATURE] 찜 토글 기능 & 찜한 가게 목록 조회

### DIFF
--- a/src/main/java/com/iitp/domains/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/iitp/domains/favorite/controller/FavoriteController.java
@@ -23,10 +23,9 @@ public class FavoriteController {
 
     @PatchMapping("/{storeId}/favorites")
     @Operation(summary = "찜 토글", description = "기존 찜 존재 여부에 따라 특정 가게에 대한 찜을 생성 혹은 삭제합니다.")
-    public ApiResponse<FavoriteToggledResponse> toggleFavorite(@PathVariable("storeId") Long storeId, @AuthenticationPrincipal
-    MemberPrincipal memberPrincipal) {
+    public ApiResponse<FavoriteToggledResponse> toggleFavorite(@PathVariable("storeId") Long storeId) {
         Long memberId = SecurityUtil.getCurrentMemberId();
-        FavoriteToggledResponse favoriteToggledResponse = favoriteCommandService.toggleFavorite(storeId);
+        FavoriteToggledResponse favoriteToggledResponse = favoriteCommandService.toggleFavorite(memberId, storeId);
         return ApiResponse.ok(200, favoriteToggledResponse, "찜 토글 완료");
     }
 }

--- a/src/main/java/com/iitp/domains/favorite/controller/FavoriteController.java
+++ b/src/main/java/com/iitp/domains/favorite/controller/FavoriteController.java
@@ -1,0 +1,33 @@
+package com.iitp.domains.favorite.controller;
+
+import com.iitp.domains.favorite.dto.Response.FavoriteToggledResponse;
+import com.iitp.domains.favorite.service.command.FavoriteCommandService;
+import com.iitp.global.common.response.ApiResponse;
+import com.iitp.global.config.security.MemberPrincipal;
+import com.iitp.global.config.security.SecurityUtil;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/stores")
+@RequiredArgsConstructor
+@Tag(name = "찜", description = "가게에 대한 찜 API")
+public class FavoriteController {
+    private final FavoriteCommandService favoriteCommandService;
+
+    @PatchMapping("/{storeId}/favorites")
+    @Operation(summary = "찜 토글", description = "기존 찜 존재 여부에 따라 특정 가게에 대한 찜을 생성 혹은 삭제합니다.")
+    public ApiResponse<FavoriteToggledResponse> toggleFavorite(@PathVariable("storeId") Long storeId, @AuthenticationPrincipal
+    MemberPrincipal memberPrincipal) {
+        Long memberId = SecurityUtil.getCurrentMemberId();
+        FavoriteToggledResponse favoriteToggledResponse = favoriteCommandService.toggleFavorite(storeId);
+        return ApiResponse.ok(200, favoriteToggledResponse, "찜 토글 완료");
+    }
+}
+

--- a/src/main/java/com/iitp/domains/favorite/domain/entity/Favorite.java
+++ b/src/main/java/com/iitp/domains/favorite/domain/entity/Favorite.java
@@ -1,0 +1,42 @@
+package com.iitp.domains.favorite.domain.entity;
+
+import com.iitp.domains.member.domain.entity.Member;
+import com.iitp.domains.store.domain.entity.Store;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "favorite")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Favorite {
+    @Id
+    @Column(name = "id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @NotNull
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @NotNull
+    @JoinColumn(name = "store_id")
+    private Store store;
+
+}

--- a/src/main/java/com/iitp/domains/favorite/dto/Response/FavoriteToggledResponse.java
+++ b/src/main/java/com/iitp/domains/favorite/dto/Response/FavoriteToggledResponse.java
@@ -1,0 +1,16 @@
+package com.iitp.domains.favorite.dto.Response;
+
+import lombok.Builder;
+
+@Builder
+public record FavoriteToggledResponse(
+        long storeId,
+        boolean isFavored
+) {
+    public static FavoriteToggledResponse of(long storeId, boolean isFavored) {
+        return FavoriteToggledResponse.builder()
+                .storeId(storeId)
+                .isFavored(isFavored)
+                .build();
+    }
+}

--- a/src/main/java/com/iitp/domains/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/iitp/domains/favorite/repository/FavoriteRepository.java
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
     Optional<Favorite> findByMemberIdAndStoreId(Long memberId, Long storeId);
+    boolean existsByMemberIdAndStoreId(Long memberId, Long storeId);
 }

--- a/src/main/java/com/iitp/domains/favorite/repository/FavoriteRepository.java
+++ b/src/main/java/com/iitp/domains/favorite/repository/FavoriteRepository.java
@@ -1,0 +1,11 @@
+package com.iitp.domains.favorite.repository;
+
+import com.iitp.domains.favorite.domain.entity.Favorite;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    Optional<Favorite> findByMemberIdAndStoreId(Long memberId, Long storeId);
+}

--- a/src/main/java/com/iitp/domains/favorite/service/command/FavoriteCommandService.java
+++ b/src/main/java/com/iitp/domains/favorite/service/command/FavoriteCommandService.java
@@ -1,0 +1,46 @@
+package com.iitp.domains.favorite.service.command;
+
+import com.iitp.domains.favorite.domain.entity.Favorite;
+import com.iitp.domains.favorite.dto.Response.FavoriteToggledResponse;
+import com.iitp.domains.favorite.repository.FavoriteRepository;
+import com.iitp.domains.member.domain.entity.Member;
+import com.iitp.domains.member.service.query.MemberQueryService;
+import com.iitp.domains.store.domain.entity.Store;
+import com.iitp.domains.store.service.query.StoreQueryService;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class FavoriteCommandService {
+    private final FavoriteRepository favoriteRepository;
+    private final MemberQueryService memberQueryService;
+    private final StoreQueryService storeQueryService;
+
+    public FavoriteToggledResponse toggleFavorite(Long storeId) {
+        Member member = memberQueryService.findExistingCurrentMember();
+        Store store = storeQueryService.findExistingStore(storeId);
+
+        Optional<Favorite> optionalFavorite = favoriteRepository.findByMemberIdAndStoreId(member.getId(), storeId);
+        boolean isFavored;
+        if (optionalFavorite.isEmpty()) {
+            member.addFavorite(Favorite.builder()
+                    .member(member)
+                    .store(store)
+                    .build()
+            );
+            isFavored = true;
+        } else {
+            member.removeFavorite(optionalFavorite.get());
+            isFavored = false;
+        }
+
+        return FavoriteToggledResponse.of(store.getId(), isFavored);
+    }
+
+}

--- a/src/main/java/com/iitp/domains/favorite/service/command/FavoriteCommandService.java
+++ b/src/main/java/com/iitp/domains/favorite/service/command/FavoriteCommandService.java
@@ -22,8 +22,8 @@ public class FavoriteCommandService {
     private final MemberQueryService memberQueryService;
     private final StoreQueryService storeQueryService;
 
-    public FavoriteToggledResponse toggleFavorite(Long storeId) {
-        Member member = memberQueryService.findExistingCurrentMember();
+    public FavoriteToggledResponse toggleFavorite(Long memberId, Long storeId) {
+        Member member = memberQueryService.findMemberById(memberId);
         Store store = storeQueryService.findExistingStore(storeId);
 
         Optional<Favorite> optionalFavorite = favoriteRepository.findByMemberIdAndStoreId(member.getId(), storeId);

--- a/src/main/java/com/iitp/domains/favorite/service/query/FavoriteQueryService.java
+++ b/src/main/java/com/iitp/domains/favorite/service/query/FavoriteQueryService.java
@@ -1,0 +1,19 @@
+package com.iitp.domains.favorite.service.query;
+
+import com.iitp.domains.favorite.repository.FavoriteRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class FavoriteQueryService {
+    private final FavoriteRepository favoriteRepository;
+
+    public boolean isFavoriteExists(Long memberId, Long storeId) {
+        return favoriteRepository.existsByMemberIdAndStoreId(memberId, storeId);
+    }
+}

--- a/src/main/java/com/iitp/domains/map/service/query/MapQueryService.java
+++ b/src/main/java/com/iitp/domains/map/service/query/MapQueryService.java
@@ -54,7 +54,8 @@ public class MapQueryService {
                 .collect(Collectors.toList());
 
         // DB에서 가게 정보 조회
-        List<Store> stores = mapRepository.findStoreListByIds(storeIds);;
+        List<Store> stores = mapRepository.findStoreListByIds(storeIds);
+        ;
 
         return stores.stream()
                 .map(MapMarkerResponseDto::from)
@@ -82,10 +83,9 @@ public class MapQueryService {
         // 픽업 가능 시간 생성
         String pickupTime = generatePickupTime(store);
 
-
         // 리뷰 조회
-        List<ReviewResponse> reviews = reviewQueryService.readStoreReviews(
-                null, storeId, 0L, Integer.MAX_VALUE);
+        List<ReviewResponse> reviews = reviewQueryService.getStoreReviews(
+                storeId, 0L, Integer.MAX_VALUE);
 
         Double rating = 0.0;
         Integer reviewCount = 0;
@@ -106,7 +106,8 @@ public class MapQueryService {
     /**
      * 근처 가게 목록 조회
      */
-    public List<MapListResponseDto> getNearbyStoreList(Double latitude, Double longitude, Double radiusKm, String sort) {
+    public List<MapListResponseDto> getNearbyStoreList(Double latitude, Double longitude, Double radiusKm,
+                                                       String sort) {
         log.info("근처 가게 목록 조회 - lat: {}, lng: {}, radius: {}km, sort: {}", latitude, longitude, radiusKm, sort);
 
         // Redis GEO에서 근처 가게 ID 조회
@@ -133,8 +134,8 @@ public class MapQueryService {
                             store.getLatitude(), store.getLongitude());
 
                     // 리뷰 조회
-                    List<ReviewResponse> reviews = reviewQueryService.readStoreReviews(
-                            null, store.getId(), 0L, Integer.MAX_VALUE);
+                    List<ReviewResponse> reviews = reviewQueryService.getStoreReviews(
+                            store.getId(), 0L, Integer.MAX_VALUE);
 
                     Double rating = 0.0;
                     Integer reviewCount = 0;

--- a/src/main/java/com/iitp/domains/member/domain/entity/Member.java
+++ b/src/main/java/com/iitp/domains/member/domain/entity/Member.java
@@ -1,17 +1,26 @@
 package com.iitp.domains.member.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.iitp.domains.favorite.domain.entity.Favorite;
 import com.iitp.domains.member.domain.EnvironmentLevel;
 import com.iitp.domains.member.domain.JoinType;
 import com.iitp.domains.member.domain.Role;
 import com.iitp.global.common.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Entity
 @Table(name = "member")
@@ -77,6 +86,9 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "memberId", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Location> locations = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Favorite> favorites = new ArrayList<>();
+
     @Builder
     public Member(String email, String nickname, String phone,
                   Role role, JoinType joinType, EnvironmentLevel environmentLevel,
@@ -92,6 +104,7 @@ public class Member extends BaseEntity {
         this.orderCount = 0;
         this.dishCount = 0;
     }
+
     // 일반 사용자 생성
     public static Member createMember(String email, String nickname, String phone) {
         return Member.builder()
@@ -115,7 +128,9 @@ public class Member extends BaseEntity {
                 .build();
     }
 
-    // 비즈니스 로직 메서드들
+    /**
+     * 비즈니스 로직 메서드
+     */
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
@@ -131,6 +146,7 @@ public class Member extends BaseEntity {
     public void removeRefreshToken() {
         this.refreshToken = null;
     }
+
     // 사업자 등록 승인 처리
     public void approveBusinessRegistration() {
         this.isBusinessApproved = true;
@@ -139,4 +155,17 @@ public class Member extends BaseEntity {
     public void updateFcmToken(String fcmToken) {
         this.fcmToken = fcmToken;
     }
+
+    /**
+     * 연관관계 편의 메서드
+     */
+
+    public void addFavorite(Favorite favorite) {
+        favorites.add(favorite);
+    }
+
+    public void removeFavorite(Favorite favorite) {
+        favorites.remove(favorite);
+    }
+
 }

--- a/src/main/java/com/iitp/domains/member/service/query/LocationQueryService.java
+++ b/src/main/java/com/iitp/domains/member/service/query/LocationQueryService.java
@@ -40,13 +40,16 @@ public class LocationQueryService {
     public LocationResponseDto findDefaultAddress(Long memberId) {
         log.debug("기본 주소 조회 - memberId: {}", memberId);
 
-        Location defaultLocation = locationRepository.findByMemberIdAndIsMostRecentTrueAndIsDeletedFalse(memberId)
+        Location defaultLocation = getMemberBaseLocation(memberId);
+        return LocationResponseDto.from(defaultLocation);
+    }
+
+    public Location getMemberBaseLocation(Long memberId) {
+        return locationRepository.findByMemberIdAndIsMostRecentTrueAndIsDeletedFalse(memberId)
                 .orElseThrow(() -> {
                     log.warn("기본 주소를 찾을 수 없음 - memberId: {}", memberId);
                     return new NotFoundException(ExceptionMessage.DATA_NOT_FOUND);
                 });
-
-        return LocationResponseDto.from(defaultLocation);
     }
 
     /**

--- a/src/main/java/com/iitp/domains/member/service/query/MemberQueryService.java
+++ b/src/main/java/com/iitp/domains/member/service/query/MemberQueryService.java
@@ -4,6 +4,7 @@ import com.iitp.domains.member.domain.entity.Location;
 import com.iitp.domains.member.domain.entity.Member;
 import com.iitp.domains.member.repository.LocationRepository;
 import com.iitp.domains.member.repository.MemberRepository;
+import com.iitp.global.config.security.SecurityUtil;
 import com.iitp.global.exception.ExceptionMessage;
 import com.iitp.global.exception.NotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -120,6 +121,15 @@ public class MemberQueryService {
     public Optional<Location> findMostRecentLocation(Long memberId) {
         log.debug("최근 위치 조회 - memberId: {}", memberId);
         return locationRepository.findByMemberIdAndIsMostRecentTrueAndIsDeletedFalse(memberId);
+    }
+
+    /**
+     * 현재 로그인된 회원 조회
+     * SecurityContext - Principal - id를 이용해 현재 로그인된 회원 조회
+     */
+    public Member findExistingCurrentMember() {
+        return memberRepository.findById(SecurityUtil.getCurrentMemberId())
+                .orElseThrow(()-> new NotFoundException(ExceptionMessage.MEMBER_NOT_FOUND));
     }
 
 }

--- a/src/main/java/com/iitp/domains/review/controller/query/ReviewQueryController.java
+++ b/src/main/java/com/iitp/domains/review/controller/query/ReviewQueryController.java
@@ -3,6 +3,7 @@ package com.iitp.domains.review.controller.query;
 import com.iitp.domains.review.dto.response.ReviewResponse;
 import com.iitp.domains.review.service.query.ReviewQueryService;
 import com.iitp.global.common.response.ApiResponse;
+import com.iitp.global.common.response.TwoWayCursorListResponse;
 import com.iitp.global.config.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -26,37 +27,25 @@ public class ReviewQueryController {
     @GetMapping("/{storeId}/reviews")
     @Operation(summary = "특정 가게 리뷰 조회",
             description = "가게가 존재해야 합니다.")
-    public ApiResponse<List<ReviewResponse>> readStoreReviews(
+    public ApiResponse<TwoWayCursorListResponse<ReviewResponse>> readStoreReviews(
             @PathVariable("storeId") long storeId,
             @RequestParam(value = "cursorId", defaultValue = "0") long cursorId,
             @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        Long memberId = userDetails.getMemberId();
-        System.out.println("storeId = " + storeId);
-        System.out.println("cursorId = " + cursorId);
-        System.out.println("limit = " + limit);
-        List<ReviewResponse> reviewResponses = reviewQueryService
-                .readStoreReviews(memberId, storeId, cursorId, limit);
-
-        return ApiResponse.ok(reviewResponses);
+        return ApiResponse.ok(reviewQueryService.readStoreReviews(storeId, cursorId, limit));
     }
 
     @GetMapping("/reviews/me")
     @Operation(summary = "내가 쓴 리뷰 조회",
             description = "회원이 존재해야 합니다.")
-    public ApiResponse<List<ReviewResponse>> readStoreReviews(
+    public ApiResponse<TwoWayCursorListResponse<ReviewResponse>> readStoreReviews(
             @RequestParam(value = "cursorId", defaultValue = "0") long cursorId,
             @RequestParam(value = "limit", required = false, defaultValue = "10") int limit,
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
         Long memberId = userDetails.getMemberId();
-        System.out.println("cursorId = " + cursorId);
-        System.out.println("limit = " + limit);
-        List<ReviewResponse> reviewResponses = reviewQueryService
-                .readMyReviews(memberId, cursorId, limit);
-
-        return ApiResponse.ok(reviewResponses);
+        return ApiResponse.ok(reviewQueryService.readMyReviews(memberId, cursorId, limit));
     }
 
 

--- a/src/main/java/com/iitp/domains/review/repository/ReviewRepositoryCustom.java
+++ b/src/main/java/com/iitp/domains/review/repository/ReviewRepositoryCustom.java
@@ -1,11 +1,16 @@
 package com.iitp.domains.review.repository;
 
 import com.iitp.domains.review.domain.entity.Review;
+import com.iitp.domains.review.repository.mapper.ReviewAggregationResult;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReviewRepositoryCustom {
     List<Review> findReviewsByStore(long storeId, long cursorId, int limit);
+
+    Optional<ReviewAggregationResult> findReviewRatingAverageByStore(long storeId);
+
     List<Review> findReviewsByMember(long memberId, long cursorId, int limit);
 }

--- a/src/main/java/com/iitp/domains/review/repository/ReviewRepositoryImpl.java
+++ b/src/main/java/com/iitp/domains/review/repository/ReviewRepositoryImpl.java
@@ -26,6 +26,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 .join(review.member, member).fetchJoin()
                 .where(review.store.id.eq(storeId))
                 .where(review.store.isDeleted.isFalse())
+                .where(review.isDeleted.isFalse())
                 // 기본 정렬: 최신순
                 .where(ltCursorId(cursorId))
                 .orderBy(review.id.desc())
@@ -58,6 +59,7 @@ public class ReviewRepositoryImpl implements ReviewRepositoryCustom {
                 .join(review.member, member).fetchJoin()
                 .where(review.member.id.eq(memberId))
                 .where(review.member.isDeleted.isFalse())
+                .where(review.isDeleted.isFalse())
                 // 기본 정렬: 최신순
                 .where(ltCursorId(cursorId))
                 .orderBy(review.id.desc())

--- a/src/main/java/com/iitp/domains/review/repository/mapper/ReviewAggregationResult.java
+++ b/src/main/java/com/iitp/domains/review/repository/mapper/ReviewAggregationResult.java
@@ -1,0 +1,7 @@
+package com.iitp.domains.review.repository.mapper;
+
+public record ReviewAggregationResult(
+        Double averageRating,
+        long count
+) {
+}

--- a/src/main/java/com/iitp/domains/review/service/query/ReviewQueryService.java
+++ b/src/main/java/com/iitp/domains/review/service/query/ReviewQueryService.java
@@ -1,16 +1,14 @@
 package com.iitp.domains.review.service.query;
 
-import com.iitp.domains.cart.service.query.CartQueryService;
 import com.iitp.domains.member.domain.entity.Member;
 import com.iitp.domains.member.service.query.MemberQueryService;
-import com.iitp.domains.order.repository.OrderRepository;
-import com.iitp.domains.order.service.query.OrderQueryService;
 import com.iitp.domains.review.domain.entity.Review;
 import com.iitp.domains.review.dto.response.ReviewResponse;
 import com.iitp.domains.review.repository.ReviewRepository;
 import com.iitp.domains.store.domain.entity.Menu;
 import com.iitp.domains.store.domain.entity.Store;
 import com.iitp.domains.store.service.query.StoreQueryService;
+import com.iitp.global.common.response.TwoWayCursorListResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,47 +21,44 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 public class ReviewQueryService {
     private final ReviewRepository reviewRepository;
-    // TODO: 주문 구현 완료 후 orderRepository 의존관계 제거
-    private final OrderRepository orderRepository;
     private final MemberQueryService memberQueryService;
     private final StoreQueryService storeQueryService;
-    private final OrderQueryService orderQueryService;
-    private final CartQueryService cartQueryService;
 
-    public List<ReviewResponse> readStoreReviews(
-            Long memberId,
-            Long storeId,
-            Long cursorId,
-            int limit
-    ) {
+    /**
+     * API 응답 메서드
+     */
+    public TwoWayCursorListResponse<ReviewResponse> readStoreReviews(Long storeId, Long cursorId, int limit) {
         Store store = storeQueryService.findExistingStore(storeId);
-
-        // 조회
-        List<Review> reviews = reviewRepository.findReviewsByStore(store.getId(), cursorId, limit);
-        reviews.forEach(it -> System.out.println(it.getContent()));
-
-        List<ReviewResponse> result = reviews.stream()
-                .map(it -> ReviewResponse.from(it, getOrderedMenusOfReview(it)))
-                .toList();
-        return result;
+        List<ReviewResponse> result = getStoreReviews(store.getId(), cursorId, limit);
+        return new TwoWayCursorListResponse<>(result.getFirst().id(), result.getLast().id(), result);
     }
 
-    // 내가 쓴 리뷰 목록 조회
-    public List<ReviewResponse> readMyReviews(
-            Long memberId,
-            Long cursorId,
-            int limit
-    ) {
+    public TwoWayCursorListResponse<ReviewResponse> readMyReviews(long memberId, long cursorId, int limit) {
         Member author = memberQueryService.findMemberById(memberId);
+        List<ReviewResponse> result = getMyReviews(author.getId(), cursorId, limit);
+        return new TwoWayCursorListResponse<>(result.getFirst().id(), result.getLast().id(), result);
+    }
 
-        // 조회
-        List<Review> reviews = reviewRepository.findReviewsByMember(author.getId(), cursorId, limit);
-        reviews.forEach(it -> System.out.println(it.getContent()));
+    /**
+     * 조회 및 DTO 변환
+     */
+    public List<ReviewResponse> getStoreReviews(long storeId, Long cursorId, int limit) {
+        List<Review> reviews = reviewRepository.findReviewsByStore(storeId, cursorId, limit);
+        return convertToResponse(reviews);
+    }
 
-        List<ReviewResponse> result = reviews.stream()
+    private List<ReviewResponse> getMyReviews(long authorId, Long cursorId, int limit) {
+        List<Review> reviews = reviewRepository.findReviewsByMember(authorId, cursorId, limit);
+        return convertToResponse(reviews);
+    }
+
+    /**
+     * 공통 메서드
+     */
+    private static List<ReviewResponse> convertToResponse(List<Review> reviews) {
+        return reviews.stream()
                 .map(it -> ReviewResponse.from(it, getOrderedMenusOfReview(it)))
                 .toList();
-        return result;
     }
 
     // TODO: 주문 구현 후 리뷰의 실제 주문-장바구니-메뉴 리스트 가져오는 쪽으로 수정

--- a/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
+++ b/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
@@ -70,8 +70,7 @@ public class StoreQueryController {
         TwoWayCursorListResponse<StoreListResponse> responses = storeQueryService
                 .findFavoriteStores(memberId, sort, cursorId, limit);
 
-        // TODO: ok 리팩토링 반영
-        return ApiResponse.ok(200, responses, "가게 리스트 호출 성공");
+        return ApiResponse.ok(responses);
     }
 
 }

--- a/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
+++ b/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
@@ -7,6 +7,7 @@ import com.iitp.domains.store.dto.response.StoreListResponse;
 import com.iitp.domains.store.dto.response.StoreListTotalResponse;
 import com.iitp.domains.store.service.query.StoreQueryService;
 import com.iitp.global.common.response.ApiResponse;
+import com.iitp.global.common.response.TwoWayCursorListResponse;
 import com.iitp.global.config.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -29,6 +30,7 @@ public class StoreQueryController {
     @Operation(summary = "가게 리스트 호출", description = "필터에 적합한 가게 리스트를 출력합니다.")
     @GetMapping("")
     public ApiResponse<StoreListTotalResponse> findStores(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(value = "category", required = false) Category category,
             @RequestParam(value = "keyword", required = false) String keyword,
             @RequestParam(value = "sort", required = false) SortType sort,
@@ -36,9 +38,9 @@ public class StoreQueryController {
             @RequestParam(value = "direction", defaultValue = "true") boolean direction,
             @RequestParam(value = "limit", defaultValue = "15") int limit
     ) {
-
+        Long memberId = userDetails.getMemberId();
         StoreListTotalResponse responses = storeQueryService
-                .findStores(category, keyword, sort, cursorId, direction, limit);
+                .findStores(memberId, category, keyword, sort, cursorId, direction, limit);
 
         return ApiResponse.ok(200, responses, "가게 리스트 호출 성공");
     }
@@ -55,14 +57,14 @@ public class StoreQueryController {
 
     @GetMapping("/favorites/me")
     @Operation(summary = "회원의 찜한 가게 목록 조회", description = "필터에 적합한 찜한 가게들을 출력합니다.")
-    public ApiResponse<List<StoreListResponse>> findMyFavoriteStores(
+    public ApiResponse<TwoWayCursorListResponse<StoreListResponse>> findMyFavoriteStores(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(value = "sort", required = false) SortType sort,
             @RequestParam(value = "cursorId", defaultValue = "0") Long cursorId,
             @RequestParam(value = "limit", defaultValue = "15") int limit
     ) {
         Long memberId = userDetails.getMemberId();
-        List<StoreListResponse> responses = storeQueryService
+        TwoWayCursorListResponse<StoreListResponse> responses = storeQueryService
                 .findFavoriteStores(memberId, sort, cursorId, limit);
 
         // TODO: ok 리팩토링 반영

--- a/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
+++ b/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
@@ -7,12 +7,17 @@ import com.iitp.domains.store.dto.response.StoreListResponse;
 import com.iitp.domains.store.dto.response.StoreListTotalResponse;
 import com.iitp.domains.store.service.query.StoreQueryService;
 import com.iitp.global.common.response.ApiResponse;
+import com.iitp.global.config.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.bind.annotation.*;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "가게 Query API", description = "가게 Query API")
 @RestController
@@ -24,17 +29,18 @@ public class StoreQueryController {
     @Operation(summary = "가게 리스트 호출", description = "필터에 적합한 가게 리스트를 출력합니다.")
     @GetMapping("")
     public ApiResponse<StoreListTotalResponse> findStores(
-            @RequestParam(value = "category", required=false) Category category,
-            @RequestParam(value = "keyword", required=false) String keyword,
-            @RequestParam(value = "sort", required=false)SortType sort,
-            @RequestParam(value = "cursorId",  defaultValue = "0")Long cursorId,
-            @RequestParam(value="direction", defaultValue = "true")boolean direction,
-            @RequestParam(value="limit", defaultValue = "15") int limit
-            ) {
+            @RequestParam(value = "category", required = false) Category category,
+            @RequestParam(value = "keyword", required = false) String keyword,
+            @RequestParam(value = "sort", required = false) SortType sort,
+            @RequestParam(value = "cursorId", defaultValue = "0") Long cursorId,
+            @RequestParam(value = "direction", defaultValue = "true") boolean direction,
+            @RequestParam(value = "limit", defaultValue = "15") int limit
+    ) {
 
-        StoreListTotalResponse responses = storeQueryService.findStores(category,keyword,sort,cursorId, direction, limit);
+        StoreListTotalResponse responses = storeQueryService
+                .findStores(category, keyword, sort, cursorId, direction, limit);
 
-        return ApiResponse.ok(200,  responses, "가게 리스트 호출 성공");
+        return ApiResponse.ok(200, responses, "가게 리스트 호출 성공");
     }
 
 
@@ -44,6 +50,23 @@ public class StoreQueryController {
 
         StoreDetailResponse responses = storeQueryService.findStoreData(storeId);
 
-        return ApiResponse.ok(200,  responses, "상세 가게 호출 성공");
+        return ApiResponse.ok(200, responses, "상세 가게 호출 성공");
     }
+
+    @GetMapping("/favorites/me")
+    @Operation(summary = "회원의 찜한 가게 목록 조회", description = "필터에 적합한 찜한 가게들을 출력합니다.")
+    public ApiResponse<List<StoreListResponse>> findMyFavoriteStores(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(value = "sort", required = false) SortType sort,
+            @RequestParam(value = "cursorId", defaultValue = "0") Long cursorId,
+            @RequestParam(value = "limit", defaultValue = "15") int limit
+    ) {
+        Long memberId = userDetails.getMemberId();
+        List<StoreListResponse> responses = storeQueryService
+                .findFavoriteStores(memberId, sort, cursorId, limit);
+
+        // TODO: ok 리팩토링 반영
+        return ApiResponse.ok(200, responses, "가게 리스트 호출 성공");
+    }
+
 }

--- a/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
+++ b/src/main/java/com/iitp/domains/store/controller/query/StoreQueryController.java
@@ -48,9 +48,12 @@ public class StoreQueryController {
 
     @Operation(summary = "가게 세부 내용 호출", description = "가게 세부 내용 출력합니다.")
     @GetMapping("/{storeId}")
-    public ApiResponse<StoreDetailResponse> findStore(@PathVariable Long storeId) {
-
-        StoreDetailResponse responses = storeQueryService.findStoreData(storeId);
+    public ApiResponse<StoreDetailResponse> findStore(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long storeId
+    ) {
+        Long memberId = userDetails.getMemberId();
+        StoreDetailResponse responses = storeQueryService.findStoreData(memberId, storeId);
 
         return ApiResponse.ok(200, responses, "상세 가게 호출 성공");
     }

--- a/src/main/java/com/iitp/domains/store/domain/entity/Store.java
+++ b/src/main/java/com/iitp/domains/store/domain/entity/Store.java
@@ -1,5 +1,6 @@
 package com.iitp.domains.store.domain.entity;
 
+import com.iitp.domains.favorite.domain.entity.Favorite;
 import com.iitp.domains.store.domain.Category;
 import com.iitp.domains.store.domain.StoreStatus;
 import com.iitp.domains.store.dto.request.StoreUpdateRequest;
@@ -68,6 +69,9 @@ public class Store extends BaseEntity {
 
     @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Menu> menus = new ArrayList<>();
+
+    @OneToMany(mappedBy = "store", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Favorite> favorites = new ArrayList<>();
 
 
     public void update(StoreUpdateRequest requestDto) {

--- a/src/main/java/com/iitp/domains/store/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/iitp/domains/store/dto/response/StoreDetailResponse.java
@@ -3,7 +3,7 @@ package com.iitp.domains.store.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.iitp.domains.store.domain.Category;
 import com.iitp.domains.store.domain.entity.Store;
-
+import java.math.BigDecimal;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -23,11 +23,18 @@ public record StoreDetailResponse(
         List<String> imageUrl,
         List<MenuListResponse> menus,
         boolean like,
-        double ratingAvg,
-        int count
+        Double ratingAvg,
+        long count
 ) {
 
-    public static StoreDetailResponse from(Store store, List<String> imageUrls, List<MenuListResponse> menus, boolean like, double ratingAvg, int count) {
+    public static StoreDetailResponse from(
+            Store store,
+            List<String> imageUrls,
+            List<MenuListResponse> menus,
+            boolean like,
+            Double ratingAvg,
+            long count
+    ) {
         return new StoreDetailResponse(
                 store.getName(),
                 store.getPhoneNumber(),

--- a/src/main/java/com/iitp/domains/store/dto/response/StoreListResponse.java
+++ b/src/main/java/com/iitp/domains/store/dto/response/StoreListResponse.java
@@ -9,20 +9,25 @@ public record StoreListResponse(
         StoreStatus status,
         String imageUrl,
         int discountPercent,                // 최고 할인율
-        double ratingAvg,                   // 리뷰 평균 평점
-        int count,                          // 리뷰 총 개수
+        Double ratingAvg,                   // 리뷰 평균 평점
+        long count,                          // 리뷰 총 개수
         double distance                     // 내 위치부터 가게까지 거리
 ) {
 
-    public static StoreListResponse fromQueryResult(StoreListQueryResult storeListQueryResult,String imageUrl, int percent, double rating, int count, double distance, StoreStatus status) {
+    public static StoreListResponse fromQueryResult(
+            StoreListQueryResult result,
+            String imageUrl,
+            double distance,
+            StoreStatus status
+    ) {
         return new StoreListResponse(
-                storeListQueryResult.id(),
-                storeListQueryResult.name(),
+                result.id(),
+                result.name(),
                 status,
                 imageUrl,
-                percent,
-                rating,
-                count,
+                result.maxPercent(),
+                result.ratingAvg(),
+                result.count(),
                 distance
         );
     }

--- a/src/main/java/com/iitp/domains/store/repository/mapper/StoreListQueryResult.java
+++ b/src/main/java/com/iitp/domains/store/repository/mapper/StoreListQueryResult.java
@@ -11,6 +11,8 @@ public record StoreListQueryResult(
         StoreStatus status,
         String imageKey,
         int maxPercent,
+        Double ratingAvg,                   // 리뷰 평균 평점
+        long count,                          // 리뷰 총 개수
         LocalTime openTime,
         LocalTime closeTime
 ) {

--- a/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryCustom.java
+++ b/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryCustom.java
@@ -3,17 +3,17 @@ package com.iitp.domains.store.repository.store;
 import com.iitp.domains.store.domain.Category;
 import com.iitp.domains.store.domain.SortType;
 import com.iitp.domains.store.domain.entity.Store;
-import com.iitp.domains.store.dto.response.StoreListResponse;
 import com.iitp.domains.store.repository.mapper.StoreListQueryResult;
-import org.springframework.stereotype.Repository;
-import org.springframework.web.bind.annotation.RestController;
-
-import javax.swing.text.html.Option;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.stereotype.Repository;
 
 @Repository
 public interface StoreRepositoryCustom {
     Optional<Store> findByStoreId(Long storeId);
-    List<StoreListQueryResult> findStores(Category category, String keyword, SortType sort, Long cursorId, boolean direction, int limit);
+
+    List<StoreListQueryResult> findStores(Category category, String keyword, SortType sort, Long cursorId,
+                                          boolean direction, int limit);
+
+    List<StoreListQueryResult> findFavoriteStores(long memberId, SortType sort, long cursorId, int limit);
 }

--- a/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryImpl.java
+++ b/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryImpl.java
@@ -38,7 +38,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                         store.status,
                         QueryExpressionFormatter.getImageKeyPath(storeImage.imageKey),
                         store.maxPercent,
-                        review.rating.avg(),
+                        QueryExpressionFormatter.roundDoubleByFirstDecimalPlace(review.rating.avg()),
                         review.countDistinct(),
                         store.openTime,
                         store.closeTime))
@@ -164,7 +164,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                         store.status,
                         QueryExpressionFormatter.getImageKeyPath(storeImage.imageKey),
                         store.maxPercent,
-                        review.rating.avg(),
+                        QueryExpressionFormatter.roundDoubleByFirstDecimalPlace(review.rating.avg()),
                         review.countDistinct(),
                         store.openTime,
                         store.closeTime)

--- a/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryImpl.java
+++ b/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryImpl.java
@@ -2,11 +2,11 @@ package com.iitp.domains.store.repository.store;
 
 import static com.iitp.domains.favorite.domain.entity.QFavorite.favorite;
 import static com.iitp.domains.review.domain.entity.QReview.review;
+import static com.iitp.domains.store.domain.entity.QStore.store;
+import static com.iitp.domains.store.domain.entity.QStoreImage.storeImage;
 
 import com.iitp.domains.store.domain.Category;
 import com.iitp.domains.store.domain.SortType;
-import com.iitp.domains.store.domain.entity.QStore;
-import com.iitp.domains.store.domain.entity.QStoreImage;
 import com.iitp.domains.store.domain.entity.Store;
 import com.iitp.domains.store.repository.mapper.StoreListQueryResult;
 import com.iitp.global.util.query.QueryExpressionFormatter;
@@ -14,11 +14,8 @@ import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
-import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -28,11 +25,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class StoreRepositoryImpl implements StoreRepositoryCustom {
-    private final EntityManager entityManager;
     private final JPAQueryFactory queryFactory;
-    private static final QStore store = QStore.store;
-    QStoreImage storeImage = QStoreImage.storeImage;
-
 
     @Override
     public List<StoreListQueryResult> findStores(Category category, String keyword, SortType sort, Long cursorId,

--- a/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryImpl.java
+++ b/src/main/java/com/iitp/domains/store/repository/store/StoreRepositoryImpl.java
@@ -9,6 +9,7 @@ import com.iitp.domains.store.domain.entity.QStore;
 import com.iitp.domains.store.domain.entity.QStoreImage;
 import com.iitp.domains.store.domain.entity.Store;
 import com.iitp.domains.store.repository.mapper.StoreListQueryResult;
+import com.iitp.global.util.query.QueryExpressionFormatter;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -42,7 +43,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                         store.id,
                         store.name,
                         store.status,
-                        getImageKeyPath(storeImage.imageKey),
+                        QueryExpressionFormatter.getImageKeyPath(storeImage.imageKey),
                         store.maxPercent,
                         review.rating.avg(),
                         review.countDistinct(),
@@ -108,11 +109,6 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
         }
     }
 
-
-    private com.querydsl.core.types.dsl.StringTemplate getImageKeyPath(StringPath path) {
-        return Expressions.stringTemplate("MIN({0})", path);
-    }
-
 //    @Override
 //    public List<StoreListQueryResult> findStores(Category category, String keyword, SortType sort, Long cursorId, boolean direction, int limit) {
 //
@@ -173,7 +169,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
                         store.id,
                         store.name,
                         store.status,
-                        getImageKeyPath(storeImage.imageKey),
+                        QueryExpressionFormatter.getImageKeyPath(storeImage.imageKey),
                         store.maxPercent,
                         review.rating.avg(),
                         review.countDistinct(),
@@ -238,7 +234,7 @@ public class StoreRepositoryImpl implements StoreRepositoryCustom {
     }
 
     private OrderSpecifier<?> getOrderSpecifier(String sort) {
-        Order order =  Order.DESC ;
+        Order order = Order.DESC;
 
         if (Objects.isNull(sort)) {
             return new OrderSpecifier<>(order, store.id);

--- a/src/main/java/com/iitp/domains/store/service/query/StoreQueryService.java
+++ b/src/main/java/com/iitp/domains/store/service/query/StoreQueryService.java
@@ -66,7 +66,7 @@ public class StoreQueryService {
         }
 
         // DB에서 데이터 조회
-        Store store = validateStoreExists(storeId);
+        Store store = findExistingStore(storeId);
 
         List<String> imageUrls = store.getStoreImages().stream()
                 .map(result -> getImageUrl(result.getImageKey()))
@@ -88,7 +88,7 @@ public class StoreQueryService {
     }
 
 
-    private Store validateStoreExists(Long storeId) {
+    public Store findExistingStore(Long storeId) {
         return storeRepository.findByStoreId(storeId)
                 .orElseThrow( () -> new NotFoundException(ExceptionMessage.DATA_NOT_FOUND));
     }

--- a/src/main/java/com/iitp/domains/store/service/query/StoreQueryService.java
+++ b/src/main/java/com/iitp/domains/store/service/query/StoreQueryService.java
@@ -1,8 +1,10 @@
 package com.iitp.domains.store.service.query;
 
+import com.iitp.domains.favorite.service.query.FavoriteQueryService;
 import com.iitp.domains.member.domain.entity.Location;
 import com.iitp.domains.member.service.query.LocationQueryService;
-import com.iitp.domains.member.service.query.MemberQueryService;
+import com.iitp.domains.review.repository.ReviewRepository;
+import com.iitp.domains.review.repository.mapper.ReviewAggregationResult;
 import com.iitp.domains.store.domain.Category;
 import com.iitp.domains.store.domain.SortType;
 import com.iitp.domains.store.domain.StoreStatus;
@@ -19,8 +21,11 @@ import com.iitp.global.exception.NotFoundException;
 import com.iitp.global.redis.service.RedisGeoService;
 import com.iitp.global.redis.service.StoreRedisService;
 import com.iitp.imageUpload.service.query.ImageGetService;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,8 +41,9 @@ public class StoreQueryService {
     private final StoreRepository storeRepository;
     private final ImageGetService imageGetService;
     private final MenuQueryService menuQueryService;
-    private final MemberQueryService memberQueryService;
     private final LocationQueryService locationQueryService;
+    private final FavoriteQueryService favoriteQueryService;
+    private final ReviewRepository reviewRepository;    // 의존성 리팩토링 고민
     private final StoreRedisService cacheService;
     private final RedisGeoService redisGeoService;
     private Long currentCachedStoreId = null;
@@ -45,14 +51,15 @@ public class StoreQueryService {
     public StoreListTotalResponse findStores(Long memberId, Category category, String keyword, SortType sort,
                                              Long cursorId, boolean direction, int limit) {
         Location memberLocation = locationQueryService.getMemberBaseLocation(memberId);
-        List<StoreListQueryResult> results = storeRepository.findStores(category, keyword, sort, cursorId, direction, limit);
+        List<StoreListQueryResult> results = storeRepository
+                .findStores(category, keyword, sort, cursorId, direction, limit);
         List<StoreListResponse> stores = convertQueryResultToResponse(results, memberLocation);
 
         return new StoreListTotalResponse(stores.getFirst().id(), stores.getLast().id(), stores);
     }
 
 
-    public StoreDetailResponse findStoreData(Long storeId) {
+    public StoreDetailResponse findStoreData(Long memberId, Long storeId) {
         // 캐시된 데이터가 있고, 다른 가게를 요청하는 경우
 //        if (cacheService.hasCachedData() && !storeId.equals(currentCachedStoreId)) {
 //            cacheService.clearCache();
@@ -64,7 +71,6 @@ public class StoreQueryService {
 //            return cachedData;
 //        }
 
-        // DB에서 데이터 조회
         Store store = findExistingStore(storeId);
 
         List<String> imageUrls = store.getStoreImages().stream()
@@ -73,12 +79,15 @@ public class StoreQueryService {
 
         List<MenuListResponse> menus = menuQueryService.findMenus(storeId);
 
-        // TODO :: 리뷰 연동되면 수정
-        boolean like = true;
-        double ratingAvg = 3.5;
-        int count = 100;
+        // 리팩토링 고민: 쿼리 최적화. 아예 store repository에서 Projection을 통해 review 집계 정보, favorite 여부 가져오기
+        boolean isFavored = favoriteQueryService.isFavoriteExists(memberId, storeId);
 
-        StoreDetailResponse response = StoreDetailResponse.from(store, imageUrls, menus, like, ratingAvg, count);
+        Optional<ReviewAggregationResult> reviewAggregation = reviewRepository.findReviewRatingAverageByStore(storeId);
+        Double roundedAvg = reviewAggregation.map(ReviewAggregationResult::averageRating).orElse(null);
+        long reviewCount = reviewAggregation.map(ReviewAggregationResult::count).orElse(0L);
+
+        StoreDetailResponse response = StoreDetailResponse
+                .from(store, imageUrls, menus, isFavored, roundedAvg, reviewCount);
 
         // 캐시에 저장
 //        cacheService.cacheStoreDetail(response);

--- a/src/main/java/com/iitp/global/common/response/TwoWayCursorListResponse.java
+++ b/src/main/java/com/iitp/global/common/response/TwoWayCursorListResponse.java
@@ -1,0 +1,12 @@
+package com.iitp.global.common.response;
+
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record TwoWayCursorListResponse<T>(
+        Long prevCursor,
+        Long nextCursor,
+        List<T> list
+) {
+}

--- a/src/main/java/com/iitp/global/common/response/TwoWayCursorListResponse.java
+++ b/src/main/java/com/iitp/global/common/response/TwoWayCursorListResponse.java
@@ -3,7 +3,6 @@ package com.iitp.global.common.response;
 import java.util.List;
 import lombok.Builder;
 
-@Builder
 public record TwoWayCursorListResponse<T>(
         Long prevCursor,
         Long nextCursor,

--- a/src/main/java/com/iitp/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/iitp/global/config/security/SecurityConfig.java
@@ -50,8 +50,6 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로
                         .requestMatchers(
-                                "/**", // 테스트를 위해 임시 허용(나중에 제거)
-
                                 // Swagger
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",
@@ -60,10 +58,14 @@ public class SecurityConfig {
                                 "/webjars/**",
                                 "/swagger-ui/index.html",
 
-                                "/h2-console/**",
                                 "/api/auth/**",        // 인증 관련 API
-                                "/api/**",      // 공개 API
-                                "/error"            // 에러 페이지
+                                "/api/members/check/**",    // 회원가입 입력값 검증 API
+                                "/login.html",  // 서버 로그인 테스트 페이지
+                                "/health",  // 서버 헬스체크 API
+                                "/h2-console/**",
+                                "/error",            // 에러 페이지
+                                "/"
+
 
                         ).permitAll()
 

--- a/src/main/java/com/iitp/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/iitp/global/config/security/SecurityConfig.java
@@ -50,6 +50,8 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         // 인증 없이 접근 가능한 경로
                         .requestMatchers(
+                                "/**",
+
                                 // Swagger
                                 "/v3/api-docs/**",
                                 "/swagger-ui/**",

--- a/src/main/java/com/iitp/global/redis/service/RedisGeoInitService.java
+++ b/src/main/java/com/iitp/global/redis/service/RedisGeoInitService.java
@@ -3,10 +3,13 @@ package com.iitp.global.redis.service;
 import com.iitp.domains.map.dto.StoreLocationDto;
 import com.iitp.domains.store.domain.entity.Store;
 import com.iitp.domains.store.repository.store.StoreRepository;
+import java.util.LinkedHashMap;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
+import org.springframework.data.redis.connection.RedisGeoCommands;
 import org.springframework.stereotype.Component;
 
 import java.util.List;

--- a/src/main/java/com/iitp/global/util/query/QueryExpressionFormatter.java
+++ b/src/main/java/com/iitp/global/util/query/QueryExpressionFormatter.java
@@ -1,0 +1,17 @@
+package com.iitp.global.util.query;
+
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.StringPath;
+import com.querydsl.core.types.dsl.StringTemplate;
+
+public class QueryExpressionFormatter {
+    public static NumberExpression<Double> roundDoubleByFirstDecimalPlace(NumberExpression<Double> doubleExpression) {
+        return Expressions.numberTemplate(Double.class, "round({0}, 1)", doubleExpression);
+    }
+
+    public static StringTemplate getImageKeyPath(StringPath path) {
+        return Expressions.stringTemplate("MIN({0})", path);
+    }
+
+}


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
resolved : #7 <!-- 관련된 이슈를 적어주세요 #이슈번호 -->

## 체크 리스트
- [x] 어플리케이션이 정상적으로 실행되나요?
- [ ] Gradle test를 실행했을 때, 모든 테스트가 정상적으로 통과했나요?
- [ ] Push 되지 않은 내역은 없나요?

## 구현 설명 <!-- 어떤 걸 만들었는지 대략적으로 설명해주세요 -->

- 세큐리티 화이트리스트 수정, 멤버 서비스 메서드 추가
- 찜 로직 구현

## 요구 사항과 구현 내용 <!-- 기능을 Commit 별로 잘개 쪼개고, Commit 별로 설명해주세요 -->


- https://github.com/RE-FOOD/BE/pull/14 유저 인증 정보(JWT 유틸 객체) 의존성 연결
- https://github.com/RE-FOOD/BE/pull/15 가게 엔티티 의존성 연결
- fix: security 화이트리스트 수정 
- 찜 Entity
- Member - 찜 생성, 찜 삭제 연관관계 편의 메서드
- MemberQueryService - 세큐리티 인증 객체 기반 회원 조회 로직 추가
- 찜 Service - 가게 찜 토글 로직
- 찜 Controller - 가게 찜 토글 API
- 양방향 페이지네이션 응답 공통 객체
- :star: 가게 메인 목록 조회, 찜한 가게 목록 조회에서 리뷰, 찜 연결
- fix: 리뷰 소프트 딜리트 반영, 리뷰 목록 조회 커서 페이지네이션 반영(희원님 요청)
- :skull: 가게 목록 조회 정렬 마무리 못함... (나머지 다 완료. 가까운순만 남았음. 작업중), 양방향 direction false 일 떄 두개씩 나오는 문제 @qowl880 이거 원래 이런건가?

## 리뷰 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

@dongcarry96 기존에 화이트리스트가 모든 API URL을 대상으로 하고 있어 수정했습니다.
@dongcarry96 `@PreAuthorize` 쓰는 이유가 있을까요? 지금으로써는 JWTFilter이랑 Secrity 설정이 있어서 isAuthenticated()는 제거하는게 나을거같습니다. 찾아보니까 사용자 Role 권한별로 접근제어시킬 수 있다는거같은데, 공부해봐야겠어요


📌 코드리뷰 질문 그라운드룰
<br>
✅ 코드에 대한 맥락 없이 리뷰어의 주관적인 의견을 묻거나, 단순히 현업에서는 어떻게 하는지를 묻는 질문은 코드 리뷰 본문에는 어울리지 않아요.
코드 리뷰는 변경된 코드의 목적, 의도, 품질을 중심으로 논의하는 자리예요.
<br>
✅ 코드와 관련된 질문이 있다면 PR 본문에 적기보다는, 해당 코드를 선택해 코멘트를 남겨주세요.
